### PR TITLE
Fix SSSE3 import

### DIFF
--- a/src/Kalk.Core/Modules/HardwareIntrinsics/HardwareIntrinsicsModule.cs
+++ b/src/Kalk.Core/Modules/HardwareIntrinsics/HardwareIntrinsicsModule.cs
@@ -38,6 +38,10 @@ namespace Kalk.Core.Modules
             {
                 DynamicRegister<Sse3IntrinsicsModule>();
             }
+            if (System.Runtime.Intrinsics.X86.Ssse3.IsSupported)
+            {
+                DynamicRegister<Ssse3IntrinsicsModule>();
+            }
             if (System.Runtime.Intrinsics.X86.Sse41.IsSupported)
             {
                 DynamicRegister<Sse41IntrinsicsModule>();


### PR DESCRIPTION
Fix SSSE3 not being imported. Appears to be an oversight, feel free to close if otherwise.